### PR TITLE
Improve button styles and center layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -134,6 +134,29 @@ header h1 {
   box-shadow: 0 0 0 3px rgba(229, 88, 7, 0.2);
 }
 
+#sort-select {
+  font-family: var(--font-family-sans);
+  font-size: 0.9rem;
+  font-weight: 600;
+  padding: var(--spacing-unit) calc(var(--spacing-unit) * 2.5);
+  border: 1px solid var(--color-border);
+  border-radius: var(--border-radius);
+  background-color: var(--color-surface);
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+}
+
+#sort-select:hover {
+  background-color: var(--color-background);
+  color: var(--color-text-primary);
+}
+
+#sort-select:focus {
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px rgba(229, 88, 7, 0.2);
+}
+
 #category-buttons button {
   font-family: var(--font-family-sans);
   font-size: 0.9rem;
@@ -167,6 +190,7 @@ header h1 {
   max-width: var(--container-width);
   padding: 0 calc(var(--spacing-unit) * 4);
   align-items: flex-start;
+  margin: 0 auto; /* Center the main layout */
 }
 
 #tag-sidebar {


### PR DESCRIPTION
## Summary
- add button-like styles for the A-Z sort control
- center main layout container so content doesn't stick to the left

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68626102d370832792160ac220553eed